### PR TITLE
image-builder-stage: include disclaimier about VPN access

### DIFF
--- a/cloud-dot-redhat/src/image-builder-in-stage.md
+++ b/cloud-dot-redhat/src/image-builder-in-stage.md
@@ -1,6 +1,6 @@
 # Using Image Builder in staging environment from command line
 
-Note: The staging environment requires access to the Red Hat VPN, so is only accessible to Red Hat employees at the moment.
+Note: The staging environment requires access to the Red Hat VPN, so is only accessible to Red Hat employees. This is the first step in our deployement and the production environment will be available to select outside users soon!
 
 Image Builder is an instance of an upstream image-builder project. You can find the code and report issues here: [https://github.com/osbuild/image-builder](https://github.com/osbuild/image-builder) . It provides a REST API, which is accessible using the squid.corp.redhat.com HTTP proxy server.
 

--- a/cloud-dot-redhat/src/image-builder-in-stage.md
+++ b/cloud-dot-redhat/src/image-builder-in-stage.md
@@ -1,5 +1,7 @@
 # Using Image Builder in staging environment from command line
 
+Note: The staging environment requires access to the Red Hat VPN, so is only accessible to Red Hat employees at the moment.
+
 Image Builder is an instance of an upstream image-builder project. You can find the code and report issues here: [https://github.com/osbuild/image-builder](https://github.com/osbuild/image-builder) . It provides a REST API, which is accessible using the squid.corp.redhat.com HTTP proxy server.
 
 All you need to access the service is the “curl” tool which is available on any operating system and a user account in staging environment.


### PR DESCRIPTION
The staging environment requires VPN access. Add a disclaimer to avoid confusing/disappointing people.