### PR TITLE
image-builder-stage: clarify which region we default to

### DIFF
--- a/cloud-dot-redhat/src/image-builder-in-stage.md
+++ b/cloud-dot-redhat/src/image-builder-in-stage.md
@@ -90,6 +90,6 @@ curl --user "username:password" \
 {"status":"running"}
 ```
 
-Once the status is “success”, you can go to your AWS account and check the list of available AMIs.
+Once the status is “success”, you can go to your AWS account and check the list of available AMIs. The AMI will appear in `us-east-1`.
 
-*(TODO: we need a way to identify the AMI)*
+*(TODO: we need a way to identify the AMI and region)*


### PR DESCRIPTION
We should probably expose this in the API and just return the information,
but for now at least document it so people can easily find it.