### PR TITLE
developer-guide: mention our upstream RPM repos

### DIFF
--- a/osbuild-composer/src/SUMMARY.md
+++ b/osbuild-composer/src/SUMMARY.md
@@ -11,5 +11,6 @@
 - [Developer guide](./developer-guide/developer-guide.md)
   - [OSBuild](./developer-guide/osbuild.md)
   - [osbuild-composer](./developer-guide/osbuild-composer.md)
+  - [Latest RPM builds](./developer-guide/latest-rpm-builds.md)
   - [Testing strategy](./developer-guide/testing.md)
   - [Glossary](./developer-guide/glossary.md)

--- a/osbuild-composer/src/developer-guide/latest-rpm-builds.md
+++ b/osbuild-composer/src/developer-guide/latest-rpm-builds.md
@@ -1,0 +1,17 @@
+# Latest RPM builds
+
+While developing osbuild and osbuild composer it is convenient to download the latest RPM builds directly from upstream. The repositories in osbuild organization don't use any automation from Copr or Packit, instead the RPMs are built directly in the Jenkins CI and stored in AWS under the commit hash which allows anyone to download precisely the version built from a desired commit.
+
+The URL is specified in `mockbuild.sh` scripts in osbuild and osbuild-composer repositories:
+ * [mockbuild.sh in osbuild-composer](https://github.com/osbuild/osbuild-composer/blob/f091af55d89ac9e77aa34b94e0180aacead3f32e/schutzbot/mockbuild.sh#L27)
+ * [mockbuild.sh in osbuild](https://github.com/osbuild/osbuild/blob/850ee4466f0e3335d4c21871a5f2549f2f571965/schutzbot/mockbuild.sh#L27)
+
+And the final resulting URL is displayed in the Jenkins output (available only from Red Hat VPN).
+
+*Common trap: If you click on a link to a repo, such as:*
+
+[http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild-composer/rhel-8.4/x86\_64/6b67ca34caf0ff9d31fabb398f50533c1e41c847/](http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild-composer/rhel-8.4/x86\_64/6b67ca34caf0ff9d31fabb398f50533c1e41c847/)
+
+*you will get HTTP 403 because that's a directory and we don't allow directory listing. If you prepend known file path, such as* `repodata/repomd.xml` *you will see that the repo is there:*
+
+[http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild-composer/rhel-8.4/x86\_64/6b67ca34caf0ff9d31fabb398f50533c1e41c847/repodata/repomd.xml](http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/osbuild-composer/rhel-8.4/x86\_64/6b67ca34caf0ff9d31fabb398f50533c1e41c847/repodata/repomd.xml)


### PR DESCRIPTION
They are very useful, yet it can be difficult to find them and it is
pretty common to misinterpred HTTP 403 from AWS while clicking the link
in Jenkins output.