### PR TITLE
Documentation: Fixes a type in the Web Ui section

### DIFF
--- a/osbuild-composer/src/user-guide/installation.md
+++ b/osbuild-composer/src/user-guide/installation.md
@@ -41,6 +41,6 @@ and enable `cockpit` and `osbuild-composer` services:
 
 ```
 $ sudo systemctl enable --now osbuild-composer.socket
-$ sudo systemctl enable --now cockpit
+$ sudo systemctl enable --now cockpit.socket
 ```
 


### PR DESCRIPTION
Previous command was resulting in this error:

sudo systemctl enable --now cockpit
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.
 
Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.