### PR TITLE
docs: add filesystem blueprint reference

### DIFF
--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -231,6 +231,25 @@ name = "openssh-server"
 version = "*"
 ```
 
+### Filesystem Support
+
+The blueprints can be extended to provide filesytem support. Currently the `mountpoint` and minimum partition `size` can be set. Custom mountpoints are currently only supported for `RHEL 8.5` & `RHEL 9.0`. For other distributions, only the `root` partition is supported, the size argument being an alias for the image size. 
+
+```toml
+[[customizations.filesystem]]
+mountpoint = "/var"
+size = 2147483648
+```
+In addition to the root mountpoint, `/`, the following `mountpoints` and their sub-directories are supported:
+
+- `/var`
+- `/home`
+- `/opt`
+- `/srv`
+- `/usr`
+- `/app`
+- `/data`
+
 ## Example Blueprint
 
 The following blueprint example will:
@@ -292,4 +311,8 @@ name = "widget"
 
 [[customizations.group]]
 name = "students"
+
+[[customizations.filesystem]]
+mountpoint = "/"
+size = 2147483648
 ```


### PR DESCRIPTION
Adding a section to the `blueprint-reference` for filesystem support.