### PR TITLE
bp reference: don't mention RSA explicitly

### DIFF
--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -87,7 +87,7 @@ key = "PUBLIC SSH KEY"
 ```
 The key will be added to the user's `authorized_keys` file.
 
-*Warning: `key` expects the entire content of `~/.ssh/id_rsa.pub`*
+*Warning: `key` expects the entire content of `~/.ssh/\*.pub`*
 
 ### Additional user
 


### PR DESCRIPTION
The file name is configurable. Don't mention the default case to prevent
confusion that osbuild-composer works only with RSA keys.