### PR TITLE
releasing: Add a note about scheduled releases

### DIFF
--- a/osbuild-composer/src/developer-guide/releasing.md
+++ b/osbuild-composer/src/developer-guide/releasing.md
@@ -16,6 +16,10 @@ authentication:
 
 ## Upstream release
 
+Note: [Upstream releases are done automatically][upstream-release] on a fortnightly alternating schedule, meaning one week we release osbuild and then the next week we release osbuild-composer.
+
+### Manual upstream release
+
 Navigate to your local repository in your terminal and call the `release.py` script. It will interactively take you through the following steps:
 
 1. Gather all pull request titles merged to `main` since the latest release tag
@@ -60,3 +64,4 @@ The last of releasing a new version is to create a new post on osbuild.org. Just
 [bodhi]: https://bodhi.fedoraproject.org/
 [fedora-bot]: https://github.com/osbuild/fedora-bot
 [recent-releases]: https://github.com/osbuild/osbuild-composer/tags
+[upstream-release]: https://github.com/osbuild/release-action/tree/create-tag


### PR DESCRIPTION
This update reflects the latest changes to our release actions (https://github.com/osbuild/release-action/tree/create-tag) and what is proposed here: https://github.com/osbuild/osbuild-composer/pull/2458
As a result of all these changes, we will have automated scheduled upstream releases with tags being pushed by a bot directly to the repository each Wednesday at 10UTC.

I would like us to keep the original section about creating a release tag because this workflow is still possible - and probably what we will use for components such as cockpit-composer.