### PR TITLE
Remove deprecated 'Adding news' workflow on osbuild-composer

### DIFF
--- a/osbuild-composer/src/developer-guide/workflow.md
+++ b/osbuild-composer/src/developer-guide/workflow.md
@@ -1,12 +1,5 @@
 # Workflow
 
-## Adding news
-
-When adding a new feature to a project which should be included in the release notes, or used for
-announcements, please add it under `docs/news` in the form of a short markdown document.
-
-Bug fixes, test changes, etc... should not be announced there.
-
 ## Git Workflow
 
 ### Commits


### PR DESCRIPTION
Due to https://github.com/osbuild/osbuild-composer/pull/1933, the doc/news folder has been removed, so also remove the workflow documentation that requires to add news on that folder from the developer guide.