### PR TITLE
Add OpenSCAP blueprint reference

### DIFF
--- a/osbuild-composer/src/SUMMARY.md
+++ b/osbuild-composer/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [Uploading an image to Microsoft Azure](./user-guide/uploading-to-azure.md)
     - [Uploading an image to OCI](./user-guide/uploading-to-oci.md)
   - [Uploading container images](./user-guide/uploading-to-registry.md)
+  - [OpenSCAP image remediation](./user-guide/oscap-remediation.md)
 - [Blueprint reference](./blueprint-reference/blueprint-reference.md)
 - [Image Builder service architecture](./image-builder-service/architecture.md)
   - [Backend](./image-builder-service/image-builder-crc.md)

--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -272,6 +272,20 @@ In addition to the root mountpoint, `/`, the following `mountpoints` and their s
 - `/app`
 - `/data`
 
+### OpenSCAP Support
+
+From `RHEL8.7` & `RHEL-9.1` support has been added for `OpenSCAP` build-time remediation. The blueprints accept two fields:
+- the `datastream` path to the remediation instructions
+- the `profile_id` of the desired security profile
+
+Please see [the OpenSCAP page]('../user-guide/oscap-remediation.md') for the list of available security profiles.
+
+```toml
+[customizations.oscap]
+datastream = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+profile_id = "xccdf_org.ssgproject.content_profile_cis"
+```
+
 ## Example Blueprint
 
 The following blueprint example will:
@@ -337,4 +351,8 @@ name = "students"
 [[customizations.filesystem]]
 mountpoint = "/"
 size = 2147483648
+
+[customizations.oscap]
+datastream = "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml"
+profile_id = "xccdf_org.ssgproject.content_profile_cis"
 ```

--- a/osbuild-composer/src/user-guide/oscap-remediation.md
+++ b/osbuild-composer/src/user-guide/oscap-remediation.md
@@ -1,0 +1,61 @@
+# OpenSCAP Remediation
+
+`osbuild-composer` now provides the ability to build security hardened images using the [OpenSCAP] tool. 
+This feature is available for `RHEL 8.7` (& above) and `RHEL 9.1` (& above).
+
+[OpenSCAP]: https://github.com/OpenSCAP/openscap/blob/maint-1.3/docs/manual/manual.adoc
+
+## OpenSCAP
+
+The `OpenSCAP` tool enables users to scan images for vulnerabilities and then remediate the non-compliances according to
+pre-defined security standards. A limitation of this is that it is not always trivial to fix all issues after the first
+boot of the image.
+
+## Build-time Remedation
+
+To solve this issue, an [osbuild stage] runs the `OpenSCAP` tool on the filesystem tree while the image is being built. The `OpenSCAP` tool runs 
+the standard evaluation for the given profile and applies the remediations to the image. This process enables the user to build a more completely
+hardened image compared to running the remediation on a live system.
+
+[osbuild stage]: 'https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.oscap.remediation'
+
+## Configurations
+
+`osbuild-composer` exposes to fields for the user to customize in the image blueprints:
+    - the path to the `datastream` instructions (most likely in the `/usr/share/xml/scap/ssg/content/` directory)
+    - the `profile_id` for the desired security standard
+
+The `profile_id` field accepts both the long and short forms, i.e. `cis` or `xccdf_org.ssgproject.content_profile_cis`.
+See the below table for supported profiles.
+
+`osbuild-composer` will then generate the necessary configurations for the `osbuild` stage based on the the
+user customizations. Additionally, two packages will be added to the image, `openscap-scanner` (the `OpenSCAP` tool)
+& `scap-security-guide` (this package contains the remediation instructions).
+
+> :warning: **Note**
+The the remediation stage assumes that the
+`scap-security-guide` will be used for the datastream. This pacakge is installed on the image by default. If another datastream is desired, add the necessary package to the blueprint and specify the path to the datastream in the oscap config.
+
+## Supported profiles
+
+The supported profiles are distro specific, see below:
+
+|                             | Fedora | RHEL 8.7^ | CS9/RHEL 9.1^ |
+|-----------------------------|--------|-----------|---------------|
+| ANSSI-BP-028 (enhanced)     |        |     x     |       x       |
+| ANSSI-BP-028 (high)         |        |     x     |       x       |
+| ANSSI-BP-028 (intermediary) |        |     x     |       x       |
+| ANSSI-BP-028 (minimal)      |        |     x     |       x       |
+| CIS Level 2 - Server        |        |     x     |       x       |
+| CIS Level 1 - Server        |        |     x     |       x       |
+| CIS Level 1 - Workstation   |        |     x     |       x       |
+| CIS Level 2 - Workstation   |        |     x     |       x       |
+| CUI                         |        |     x     |       x       |
+| Essential Eight             |        |     x     |       x       |
+| HIPAA                       |        |     x     |       x       |
+| ISM Official                |        |     x     |       x       |
+| OSPP                        |    x   |     x     |       x       |
+| PCI-DSS                     |    x   |     x     |       x       |
+| Standard                    |    x   |           |               |
+| DISA STIG                   |        |     x     |       x       |
+| DISA STIG with GUI          |        |     x     |       x       |


### PR DESCRIPTION
Update the blueprint reference with info on how to specify OpenSCAP remediation customizations.
Document supported profiles for each distro.

Depends on: https://github.com/osbuild/osbuild-composer/pull/2695