### PR TITLE
Fix architecture diagram by adding plantuml

### DIFF
--- a/.github/workflows/build-guides.yml
+++ b/.github/workflows/build-guides.yml
@@ -1,6 +1,7 @@
 name: Build guides
 
 on:
+  pull_request:
   push:
     branches:
     - main
@@ -31,8 +32,12 @@ jobs:
     - name: Render osbuild-composer guide
       working-directory: sources/osbuild-composer
       run: |
+        sudo apt update && sudo apt install -y librust-openssl-dev cargo graphviz plantuml
+        cargo install mdbook-plantuml
+        export PATH=$PATH:$HOME/.cargo/bin
         mdbook build -d ../../rendered/docs/
-    - name: Publish the rendered
+    - name: Publish the rendered guide
+      if: ${{ github.ref == 'ref/heads/main' }}
       working-directory: rendered
       run: |
         pwd

--- a/osbuild-composer/book.toml
+++ b/osbuild-composer/book.toml
@@ -7,3 +7,6 @@ title = "OSBuild guides"
 
 [output.html]
 site-url = "https://www.osbuild.org/guides/"
+
+[preprocessor.plantuml]
+plantuml-cmd="plantuml"


### PR DESCRIPTION
The mdbook definition needs to have the plantuml preprocessor enabled so the architectural diagram in
osbuild-composer/src/image-builder-service/architecture.md gets compiled and displayed correctly.

Therefore I touched the GitHub Action to install the necessary pre-requisites for compiling plantuml with mdbook.

I also modified the GitHub Action to run the build on every new pull request to verify everything builds correctly (similar to what we do with the internal guides), but skipping the publishing step.