### PR TITLE
Add container credentials information

### DIFF
--- a/osbuild-composer/src/SUMMARY.md
+++ b/osbuild-composer/src/SUMMARY.md
@@ -4,6 +4,7 @@
   - [osbuild-composer description](./user-guide/osbuild-composer-description.md)
   - [Installation and configuration](./user-guide/installation.md)
     - [Managing repositories](./user-guide/managing-repositories.md)
+	- [Container registry credentials](./user-guide/container-auth.md)
   - [Creating images with the CLI interface](./user-guide/building-an-image-from-cli.md)
     - [Building OSTree image](./user-guide/building-ostree-images.md)
     - [Building OSTree container and installer](./user-guide/edge-container+installer.md)

--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -57,6 +57,10 @@ To embed the latest fedora container from http://quay.io, add this to your bluep
 source = "quay.io/fedora/fedora:latest"
 ```
 
+To access protected container resources a `containers-auth.json(5)` file can be used,
+see [Container registry credentials](../user-guide/container-auth.md).
+
+
 ## Groups
 
 The `[[groups]]` entries describe a group of packages to be installed into the image. Package groups are defined in the repository metadata. Each group has a descriptive name used primarily for display in user interfaces and an ID more commonly used in kickstart files. Here, the ID is the expected way of listing a group.

--- a/osbuild-composer/src/user-guide/container-auth.md
+++ b/osbuild-composer/src/user-guide/container-auth.md
@@ -1,0 +1,19 @@
+# Container registry credentials
+
+All communication with container registries is done by the `osbuild-worker`
+service. It can be configured via the `/etc/osbuild-worker/osbuild-worker.toml`
+configuration file. It is read only once at on service start, so the service
+needs to be restarted after making any changes.
+
+The configuration file has a `containers` section with an `auth_file_path`
+field that is a string referring to a path of a`containers-auth.json(5)` file
+to be used for accessing protected resources. An example configuration could
+look like this:
+
+```Toml
+[containers]
+auth_file_path = "/etc/osbuild-worker/containers-auth.json"
+```
+
+For detail information about the format of the authorization file itself,
+refer to the corresponding man page: `man 5 containers-auth.json`.

--- a/osbuild-composer/src/user-guide/uploading-to-registry.md
+++ b/osbuild-composer/src/user-guide/uploading-to-registry.md
@@ -24,3 +24,6 @@ username = "USERNAME"  # optional, username to use
 password = "PASSWORD"  # optional, password to use
 ```
 
+Instead of specifying `username` and `password` directly, a central
+`containers-auth.json(5)` file can be used, see
+[Container registry credentials](./container-auth.md).


### PR DESCRIPTION
Add a section how to configure container authorization and link from the blueprint guide as well as the container upload guide.