### PR TITLE
Document Koji integration + small fixes

### DIFF
--- a/osbuild-composer/src/SUMMARY.md
+++ b/osbuild-composer/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [Backend](./image-builder-service/image-builder-crc.md)
   - [Composer](./image-builder-service/image-builder-composer.md)
   - [Workers](./image-builder-service/image-builder-workers.md)
+  - [Koji integration](./image-builder-service/image-builder-koji.md)
 - [Developer guide](./developer-guide/developer-guide.md)
   - [Workflow](./developer-guide/workflow.md)
   - [Code style](./developer-guide/code-style.md)

--- a/osbuild-composer/src/developer-guide/osbuild-composer.md
+++ b/osbuild-composer/src/developer-guide/osbuild-composer.md
@@ -16,12 +16,14 @@ We use our custom wrapper for `dnf`, which we call simply `dnf-json`, because it
 
 This API comes from the `Lorax-composer project`. `osbuild-composer` was created as a drop-in replacement for Lorax which influenced many design decisions. It uses Unix-Domain socket, so it is meant for local usage only. There are two clients:
 
-* composer-cli
-* cockpit-composer (branded as Image Builder in the Cockpit console)
+* composer-cli / [weldr-client](https://github.com/osbuild/weldr-client)
+* [cockpit-composer](https://github.com/osbuild/cockpit-composer) (branded as Image Builder in the Cockpit console)
 
 Activate this API by invoking `systemctl start osbuild-composer.socket`. Systemd will create a socket at `/run/weldr/api.socket`.
 
-## Remote APIs - Cloud and Koji
+## Remote API - Cloud API
 
-Both are under heavy development.
+This is the `/api/image-builder-composer/v2/` API endpoint. There are currently two clients, which are integrating with `osbuild-composer` using this API:
 
+* [image-builder](https://github.com/osbuild/image-builder), described in more detail in the [Image Builder service architecture](./image-builder-service/architecture.md) document.
+* [koji-osbuild](https://github.com/osbuild/koji-osbuild) plugin, which integrates `osbuild-composer` with the [Koji](https://koji.build/) build system.

--- a/osbuild-composer/src/image-builder-service/image-builder-composer.md
+++ b/osbuild-composer/src/image-builder-service/image-builder-composer.md
@@ -12,6 +12,14 @@ other side of the job queue, where jobs can be dequeued to be executed and their
 
 The actual jobs are executed by `workers`, which is outside the scope of this document.
 
+## Multitenancy
+
+`osbuild-composer` deployments in both [api.openshift.com](https://api.openshift.com/) and [api.stage.openshift.com](https://api.stage.openshift.com/) have support for running builds for multiple tenants. Jobs created by a tenant can be picked only by workers belonging to the same tenant.
+
+The tenant of an API request is currently determined from the JWT token that the API caller used. Specifically, the implementation extracts the tenant ID from `rh-org-id` or `account_id` fields. This is defined in [the deployment template](https://github.com/osbuild/osbuild-composer/blob/de72b36dddfc703d76d79479dde7b92f0a78e924/templates/composer.yml#L261).
+
+Internally in `osbuild-composer`, the tenant ID is prefixed with `org-` and saved to the jobqueue as a `channel`, see [composer's source code](https://github.com/osbuild/osbuild-composer/blob/de72b36dddfc703d76d79479dde7b92f0a78e924/pkg/jobqueue/jobqueue.go#L35).
+
 ## Technology Stack
 The service is written in Golang, and the list of dependencies can be found in
 [go.mod](https://github.com/osbuild/osbuild-composer/blob/main/go.mod).

--- a/osbuild-composer/src/image-builder-service/image-builder-koji.md
+++ b/osbuild-composer/src/image-builder-service/image-builder-koji.md
@@ -1,0 +1,96 @@
+# Image Builder Koji integration
+
+This document describes how various instances of the [Koji](https://koji.build/) build system can and do integrate with the Image Builder service.
+
+## Architecture
+
+`osbuild-composer` can integrate with a `Koji` instance as an external Content Generator using the [koji-osbuild](https://github.com/osbuild/koji-osbuild) plugin. The overview of the integration is described in the [koji-osbuild project README](https://github.com/osbuild/koji-osbuild/blob/main/README.md).
+
+In short, a `Koji` instance integrates directly with `osbuild-composer` API, usually as a separate tenant with a dedicated set of workers.
+
+## Technology Stack
+
+The [koji-osbuild](https://github.com/osbuild/koji-osbuild) plugin is implemented in Python, and the list of dependencies can be found in the [SPEC file](https://github.com/osbuild/koji-osbuild/blob/main/koji-osbuild.spec).
+
+## Building images via Koji integration
+
+The `koji-osbuild` plugin allows one to submit image builds via the Koji Hub API using the `osbuildImage` task. The accepted arguments schema of the `osbuildImage` task is described [in the plugin implementation](https://github.com/osbuild/koji-osbuild/blob/cc3e621754d99b3f2a4fcb85bb207bf76a0970ea/plugins/hub/osbuild.py#L12-L225). The `koji-osbuild` plugin processes the request and submits a new compose request using the `osbuild-composer` Cloud API. The plugin always sets the [`koji` property](https://github.com/osbuild/osbuild-composer/blob/434362e81ed996e6353360c3311090ae1cbe73a6/internal/cloudapi/v2/openapi.v2.yml#L736-L737) in the compose request, signaling to `osbuild-composer` that the request is coming from a `Koji` plugin.
+
+Images built as part of a compose requests submitted via the `Koji` plugin are always implicitly uploaded to the respective `Koji` instance. Since **version 10** of the `koji-osbuild` plugin, images can be uploaded directly to the appropriate cloud environment, in addition to being uploaded to `Koji`. More details are below in the [Cloud upload](#cloud-upload) section.
+
+The `koji-osbuild` plugin also supports specifying all image customizations supported by the `osbuild-composer` Cloud API.
+
+There are currently two easy ways how to trigger the `osbuildImage` tasks in Koji:
+
+* `koji-cli` - the command line client for interacting with `Koji`. The prerequisite is to install the `koji-osbuild-cli` plugin. For more information, run `koji osbuild-image --help`.
+* [Pungi](https://pagure.io/pungi) - a distribution compose tool. `Pungi` interacts directly with the `Koji` Hub API and is able to submit `osbuildImage` tasks as part of a distribution compose. The details of how to configure `Pungi` to trigger image builds are described in the [project documentation](https://docs.pagure.org/pungi/configuration.html#osbuild-composer-for-building-images).
+
+### Cloud upload
+
+#### Prerequisites
+
+* `koji-osbuild` version >= 10
+* `osbuild-composer` version >= 58
+
+#### Details
+
+Images built via the `Koji` integration can be automatically uploaded to the appropriate cloud environment, in addition to the `Koji` instance. In order for this to happen, one must provide *upload_options* when using the `osbuildImage` task and the integrated `osbuild-composer` instance must be configured appropriately to be able to upload to the respective cloud environments.
+
+Currently supported *upload_options* are:
+
+* AWS EC2
+* AWS S3
+* Azure (as an image)
+* GCP
+* Container registry
+
+Please note, that each image type can be uploaded only to its respective cloud target, represented by *upload_options* (e.g. the `ami` image can be uploaded only to `AWS EC2`, `gce` image can be uploaded only to `GCP`, etc.).
+
+The allowed *upload_options* schema is defined in the [`koji-osbuild` Hub plugin](https://github.com/osbuild/koji-osbuild/blob/cc3e621754d99b3f2a4fcb85bb207bf76a0970ea/plugins/hub/osbuild.py#L110-L118) and currently matches the [`osbuild-composer` Cloud API `UploadOptions`](https://github.com/osbuild/osbuild-composer/blob/434362e81ed996e6353360c3311090ae1cbe73a6/internal/cloudapi/v2/openapi.v2.yml#L809-L815).
+
+If the compose request contains multiple image requests (meaning that multiple images will be built), the provided *upload_options* will be used as is for all images (with all its consequences).
+
+All the necessary data to locate the image in the cloud is attached by the `koji-osbuild` plugin to the image build task in `Koji` as `compose-status.json` file. Below is an example of such file:
+
+```json
+{
+    "image_statuses": [
+        {
+            "status": "success",
+            "upload_status": {
+                "options": {
+                    "ami": "ami-02e34403c421dfc17",
+                    "region": "us-east-1"
+                },
+                "status": "success",
+                "type": "aws"
+            }
+        }
+    ],
+    "koji_build_id": 1,
+    "koji_task_id": null,
+    "status": "success"
+}
+```
+
+#### Cloud upload via `koji-cli`
+
+In order to upload images to the cloud when using `koji-cli`, one must first create a JSON file with the appropriate *upload_options*.
+
+Example `gcp_upload_options.json`:
+
+```json
+{
+    "region": "eu",
+    "bucket": "my-bucket",
+    "share_with_accounts": ["alice@example.org"]
+}
+```
+
+Then add the `--upload-options=gcp_upload_options.json` argument to the command line when calling `koji` CLI.
+
+#### Cloud upload via `Pungi`
+
+In order to upload images to the cloud, when using `Pungi` to trigger image builds, one must specify the `upload_options` option in the configuration dictionary as described in the [project documentation](https://docs.pagure.org/pungi/configuration.html#osbuild-composer-for-building-images).
+
+Please note that the support for cloud upload has been merged to the `Pungi` project after the **4.3.6** release. Therefore, if you want to take advantage of this feature, make sure to use version higher than **4.3.6**.


### PR DESCRIPTION
- Add a section describing how Image Builder integrates with Koji.
- Move a note about Image Builder multitenancy from internal guide to the public one. This is relevant for the Koji integration, which is usually integrated as a separate tenant.
- Update the section describing local and remote APIs of `osbuild-composer`.