### PR TITLE
Add /tmp to the list of supported mountpoints

### DIFF
--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -271,6 +271,7 @@ In addition to the root mountpoint, `/`, the following `mountpoints` and their s
 - `/usr`
 - `/app`
 - `/data`
+- `/tmp`
 
 ### OpenSCAP Support
 


### PR DESCRIPTION
The `/tmp` mountpoint was mistakenly left out
of the allowlist for previous distros.