### PR TITLE
Service: Refresh architecture diagram w hyperlinks

### DIFF
--- a/osbuild-composer/src/image-builder-service/architecture.md
+++ b/osbuild-composer/src/image-builder-service/architecture.md
@@ -3,62 +3,7 @@
 This diagram shows the overall architecture, and each sub-section goes into details about the three main
 components, which are run as independent services.
 
-```plantuml
-@startuml
-
-skinparam defaultTextAlignment center
-
-!define SPRITESURL https://raw.githubusercontent.com/plantuml-stdlib/gilbarbara-plantuml-sprites/v1.0/sprites
-!includeurl SPRITESURL/openshift.puml
-
-!include <aws/common>
-!include <aws/Compute/AmazonEC2/AmazonEC2>
-!include <aws/Compute/AmazonEC2/instances/instances>
-!include <aws/Database/AmazonRDS/AmazonRDS.puml>
-!include <aws/Database/AmazonRDS/PostgreSQLinstance/PostgreSQLinstance>
-
-skinparam linetype ortho
-
-actor actor
-
-component "<$openshift>\napi.openshift.com" as oc {
-    rectangle "image-builder-composer"
-
-}
-
-component "<$openshift>\nconsole.redhat.com" as crc {
-    rectangle "image-builder-frontend"
-    rectangle "image-builder-backend"
-
-}
-
-AMAZONEC2(ec2) {
-    INSTANCES(workerfleet, worker fleet)
-}
-
-AMAZONRDS(ibdb) {
-    POSTGRESQLINSTANCE(db1, image-builder-db\ninsights account)
-}
-
-AMAZONRDS(composerdb) {
-    POSTGRESQLINSTANCE(db2, composer-db\nappsre account)
-}
-
-actor -right-> [image-builder-frontend]: **A**
-[image-builder-frontend] -right-> [image-builder-backend]
-[image-builder-backend] -down-> db1
-[image-builder-composer] -down-> db2
-[image-builder-backend] -right-> [image-builder-composer]: **B**
-workerfleet -> [image-builder-composer]: **C**
-
-legend right
-A. User connection to image builder's frontend under crc/insights/image-builder, using RH SSO for auth.
-B. Image builder's backend connects to composer to queue/query images, using RH SSO for auth.
-C. The workers connect to composer to request jobs and post results.
-endlegend
-
-@enduml
-```
+{{#include architecture.svg}}
 
 The metadata defining the service for App-Interface is kept upstream and open as templates for both the [osbuild-composer](https://github.com/osbuild/osbuild-composer/blob/main/templates/composer.yml) and [image-builder components](https://github.com/osbuild/image-builder/blob/main/templates/image-builder.yml).
 The tooling to operate the service is to large parts open source and publicly accessible, e.g. qontract in the form of [qontract-server](https://github.com/app-sre/qontract-server), [qontract-reconcile](https://github.com/app-sre/qontract-reconcile).

--- a/osbuild-composer/src/image-builder-service/architecture.svg
+++ b/osbuild-composer/src/image-builder-service/architecture.svg
@@ -1,0 +1,453 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="artwork"
+   viewBox="0 0 760 311.63"
+   version="1.1"
+   sodipodi:docname="306_OpenShift_OSBuild_upstream_0123.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview177"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.7118421"
+     inkscape:cx="287.99385"
+     inkscape:cy="155.97233"
+     inkscape:window-width="2560"
+     inkscape:window-height="1371"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="artwork" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">
+      .cls-1, .cls-2, .cls-3 {
+        fill: none;
+      }
+      .cls-2 {
+        stroke: #06c;
+      }
+      .cls-2, .cls-4 {
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .cls-5 {
+        fill: #06c;
+      }
+      .cls-6, .cls-4 {
+        fill: #fff;
+      }
+      .cls-7 {
+        fill: #e8e8e8;
+      }
+      .cls-8, .cls-9 {
+        font-family: RedHatTextRoman-Medium, 'Red Hat Text';
+        font-variation-settings: 'wght' 500;
+        font-weight: 500;
+      }
+      .cls-8, .cls-10, .cls-11 {
+        fill: #151515;
+        font-size: 12px;
+      }
+      .cls-12 {
+        fill: #ececec;
+        font-size: 10px;
+      }
+      .cls-12, .cls-13 {
+        font-family: RedHatTextRoman-Regular, 'Red Hat Text';
+        font-variation-settings: 'wght' 400;
+      }
+      .cls-3 {
+        stroke: #adadad;
+        stroke-miterlimit: 10;
+      }
+      .cls-4 {
+        stroke: #5b5b5b;
+        stroke-width: 1.5px;
+      }
+      .cls-11 {
+        font-family: RedHatTextRoman-Bold, 'Red Hat Text';
+        font-variation-settings: 'wght' 700;
+        font-weight: 700;
+      }
+    </style>
+  </defs>
+  <g
+     id="g12">
+    <text
+       class="cls-12"
+       transform="translate(715.77 294.65)"
+       id="text8"><tspan
+         x="0"
+         y="0"
+         id="tspan6">306_0123</tspan></text>
+    <rect
+       class="cls-1"
+       y="271.63"
+       width="760"
+       height="40"
+       id="rect10" />
+  </g>
+  <g
+     id="g20">
+    <rect
+       class="cls-7"
+       x="575"
+       y="20"
+       width="185"
+       height="114.5"
+       transform="translate(1335 154.5) rotate(-180)"
+       id="rect14" />
+    <text
+       class="cls-11"
+       transform="translate(590 43.85)"
+       id="text18"><tspan
+         x="0"
+         y="0"
+         id="tspan16">AmazonEC2</tspan></text>
+  </g>
+  <rect
+     class="cls-7"
+     x="375"
+     y="20"
+     width="175"
+     height="114.5"
+     transform="translate(925 154.5) rotate(-180)"
+     id="rect22" />
+  <text
+     class="cls-11"
+     transform="translate(390 43.85)"
+     id="text26"><tspan
+       x="0"
+       y="0"
+       id="tspan24">api.openshift.com</tspan></text>
+  <a
+     id="a403"
+     xlink:href="https://github.com/osbuild/osbuild-composer">
+    <g
+       id="g40">
+      <g
+         id="g32">
+        <rect
+           class="cls-6"
+           x="390.5"
+           y="60"
+           width="144"
+           height="49"
+           id="rect28" />
+        <path
+           class="cls-5"
+           d="M534,60.5v48h-143V60.5h143m1-1h-145v50h145V59.5h0Z"
+           id="path30" />
+      </g>
+      <text
+         class="cls-8"
+         transform="translate(420.17 81.44)"
+         id="text38"><tspan
+           x="0"
+           y="0"
+           id="tspan34">image-builder-</tspan><tspan
+           x="14.45"
+           y="13"
+           id="tspan36">composer</tspan></text>
+    </g>
+  </a>
+  <rect
+     class="cls-7"
+     x="375"
+     y="159.5"
+     width="175"
+     height="135"
+     transform="translate(925 454) rotate(-180)"
+     id="rect42" />
+  <rect
+     class="cls-7"
+     x="175"
+     y="159.5"
+     width="175"
+     height="135"
+     transform="translate(525 454) rotate(-180)"
+     id="rect44" />
+  <text
+     class="cls-11"
+     transform="translate(390 279.57)"
+     id="text48"><tspan
+       x="0"
+       y="0"
+       id="tspan46">AmazonRDS</tspan></text>
+  <text
+     class="cls-11"
+     transform="translate(190 279.57)"
+     id="text52"><tspan
+       x="0"
+       y="0"
+       id="tspan50">AmazonRDS</tspan></text>
+  <rect
+     class="cls-7"
+     x="0"
+     y="20"
+     width="350"
+     height="114.5"
+     transform="translate(350 154.5) rotate(-180)"
+     id="rect54" />
+  <g
+     id="g76">
+    <g
+       id="g64">
+      <path
+         class="cls-4"
+         d="M262.5,184.25c-10.19,0-18.45,4.06-18.45,9.69v16.94c0,5.63,8.26,10.19,18.45,10.19s18.45-4.56,18.45-10.19v-16.94c0-5.63-8.26-9.69-18.45-9.69Z"
+         id="path56" />
+      <path
+         class="cls-4"
+         d="M280.95,205.19c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19"
+         id="path58" />
+      <path
+         class="cls-4"
+         d="M280.95,199.44c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19"
+         id="path60" />
+      <path
+         class="cls-4"
+         d="M280.95,193.94c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19,8.26-9.69,18.45-9.69,18.45,4.06,18.45,9.69Z"
+         id="path62" />
+    </g>
+    <text
+       class="cls-10"
+       transform="translate(212.83 238.72)"
+       id="text74"><tspan
+         class="cls-9"
+         id="tspan68"><tspan
+           x="0"
+           y="0"
+           id="tspan66">image-builder-db</tspan></tspan><tspan
+         class="cls-13"
+         id="tspan72"><tspan
+           x="1.16"
+           y="15"
+           id="tspan70">(Insights account)</tspan></tspan></text>
+  </g>
+  <g
+     id="g82">
+    <line
+       class="cls-2"
+       x1="180.83"
+       y1="84.5"
+       x2="165.01"
+       y2="84.5"
+       id="line78" />
+    <polygon
+       class="cls-5"
+       points="179.37 79.51 188.01 84.5 179.37 89.49 179.37 79.51"
+       id="polygon80" />
+  </g>
+  <g
+     id="g88">
+    <line
+       class="cls-2"
+       x1="262.5"
+       y1="173.79"
+       x2="262.5"
+       y2="109.5"
+       id="line84" />
+    <polygon
+       class="cls-5"
+       points="267.49 172.34 262.5 180.97 257.51 172.34 267.49 172.34"
+       id="polygon86" />
+  </g>
+  <g
+     id="g110">
+    <g
+       id="g98">
+      <path
+         class="cls-4"
+         d="M462.5,184.25c-10.19,0-18.45,4.06-18.45,9.69v16.94c0,5.63,8.26,10.19,18.45,10.19s18.45-4.56,18.45-10.19v-16.94c0-5.63-8.26-9.69-18.45-9.69Z"
+         id="path90" />
+      <path
+         class="cls-4"
+         d="M480.95,205.19c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19"
+         id="path92" />
+      <path
+         class="cls-4"
+         d="M480.95,199.44c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19"
+         id="path94" />
+      <path
+         class="cls-4"
+         d="M480.95,193.94c0,5.63-8.26,10.19-18.45,10.19s-18.45-4.56-18.45-10.19,8.26-9.69,18.45-9.69,18.45,4.06,18.45,9.69Z"
+         id="path96" />
+    </g>
+    <text
+       class="cls-10"
+       transform="translate(424.51 238.72)"
+       id="text108"><tspan
+         class="cls-9"
+         id="tspan102"><tspan
+           x="0"
+           y="0"
+           id="tspan100">composer-db</tspan></tspan><tspan
+         class="cls-13"
+         id="tspan106"><tspan
+           x="-12.14"
+           y="15"
+           id="tspan104">(AppSRE account)</tspan></tspan></text>
+  </g>
+  <g
+     id="g116">
+    <line
+       class="cls-2"
+       x1="462.5"
+       y1="173.79"
+       x2="462.5"
+       y2="109.5"
+       id="line112" />
+    <polygon
+       class="cls-5"
+       points="467.49 172.34 462.5 180.97 457.51 172.34 467.49 172.34"
+       id="polygon114" />
+  </g>
+  <g
+     id="g122">
+    <line
+       class="cls-2"
+       x1="380.32"
+       y1="84.5"
+       x2="335"
+       y2="84.5"
+       id="line118" />
+    <polygon
+       class="cls-5"
+       points="378.86 79.51 387.5 84.5 378.86 89.49 378.86 79.51"
+       id="polygon120" />
+  </g>
+  <g
+     id="g128">
+    <line
+       class="cls-2"
+       x1="590"
+       y1="84.5"
+       x2="544.68"
+       y2="84.5"
+       id="line124" />
+    <polygon
+       class="cls-5"
+       points="546.14 79.51 537.5 84.5 546.14 89.49 546.14 79.51"
+       id="polygon126" />
+  </g>
+  <text
+     class="cls-11"
+     transform="translate(15 43.85)"
+     id="text132"><tspan
+       x="0"
+       y="0"
+       id="tspan130">console.redhat.com</tspan></text>
+  <a
+     id="a294"
+     xlink:href="https://github.com/RedHatInsights/image-builder-frontend">
+    <g
+       id="g146"
+       onclick="https://github.com/RedHatInsights/image-builder-frontend">
+      <g
+         id="g138">
+        <rect
+           class="cls-6"
+           x="15.5"
+           y="60"
+           width="149"
+           height="49"
+           id="rect134" />
+        <path
+           class="cls-5"
+           d="M164,60.5v48H16V60.5H164m1-1H15v50H165V59.5h0Z"
+           id="path136" />
+      </g>
+      <text
+         class="cls-8"
+         transform="translate(50.17 81.44)"
+         id="text144"><tspan
+           x="0"
+           y="0"
+           id="tspan140">image-builder-</tspan><tspan
+           x="17.37"
+           y="13"
+           id="tspan142">frontend</tspan></text>
+    </g>
+  </a>
+  <polyline
+     class="cls-3"
+     points="595 114.5 740 114.5 740 64.5"
+     id="polyline148" />
+  <polyline
+     class="cls-3"
+     points="600 119.5 745 119.5 745 69.5"
+     id="polyline150" />
+  <a
+     id="a510"
+     xlink:href="https://github.com/osbuild/osbuild">
+    <g
+       id="g502">
+      <g
+         id="g156">
+        <rect
+           class="cls-6"
+           x="590.5"
+           y="60"
+           width="144"
+           height="49"
+           id="rect152" />
+        <path
+           class="cls-5"
+           d="M734,60.5v48h-143V60.5h143m1-1h-145v50h145V59.5h0Z"
+           id="path154" />
+      </g>
+      <text
+         class="cls-8"
+         transform="translate(628.43 88)"
+         id="text160"><tspan
+           x="0"
+           y="0"
+           id="tspan158">worker fleet</tspan></text>
+    </g>
+  </a>
+  <a
+     id="a303"
+     xlink:href="https://github.com/osbuild/image-builder">
+    <g
+       id="g174">
+      <g
+         id="g166">
+        <rect
+           class="cls-6"
+           x="190.5"
+           y="60"
+           width="144"
+           height="49"
+           id="rect162" />
+        <path
+           class="cls-5"
+           d="M334,60.5v48H191V60.5h143m1-1H190v50h145V59.5h0Z"
+           id="path164" />
+      </g>
+      <text
+         class="cls-8"
+         transform="translate(220.17 81.44)"
+         id="text172"><tspan
+           x="0"
+           y="0"
+           id="tspan168">image-builder-</tspan><tspan
+           x="18.4"
+           y="13"
+           id="tspan170">backend</tspan></text>
+    </g>
+  </a>
+</svg>


### PR DESCRIPTION
The architecture diagram now follows a similar style as we use in other places, e.g. koji-osbuild.
Furthermore, each component of our service now holds a direct link to the corresponding GitHub repository. For simplicity, I have linked the 'worker fleet' to the osbuild repository.
Also, the legend that was shown below the diagram explaining the authentication mechanisms between the pieces of the service has been omitted (see below).
![image](https://user-images.githubusercontent.com/261436/214846377-0da847dc-0d06-4204-9086-7719467ad7ac.png)


Please note that the hyperlink rendering only works when including the svg file in markdown via {{#include }}. Furthermore, the svg's source cannot contain empty newlines or routines that might be interpreted as markdown. Otherwise it will fail to render correctly.