### PR TITLE
github-action: Remove plantuml mdbook preprocessor

### DIFF
--- a/.github/workflows/build-guides.yml
+++ b/.github/workflows/build-guides.yml
@@ -32,9 +32,6 @@ jobs:
     - name: Render osbuild-composer guide
       working-directory: sources/osbuild-composer
       run: |
-        sudo apt update && sudo apt install -y librust-openssl-dev cargo graphviz plantuml
-        cargo install mdbook-plantuml
-        export PATH=$PATH:$HOME/.cargo/bin
         mdbook build -d ../../rendered/docs/
     - name: Publish the rendered guide
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/osbuild-composer/book.toml
+++ b/osbuild-composer/book.toml
@@ -7,6 +7,3 @@ title = "OSBuild guides"
 
 [output.html]
 site-url = "https://www.osbuild.org/guides/"
-
-[preprocessor.plantuml]
-plantuml-cmd="plantuml"


### PR DESCRIPTION
As we don't have any uml diagrams in our docs anymore, we can remove the plantuml preprocessor from the GitHub Action. It was originally added in fcd8cffa07378ba911e4c2400237044415e86dde