### PR TITLE
user-guide: explaination on custom repositories

### DIFF
--- a/osbuild-composer/src/SUMMARY.md
+++ b/osbuild-composer/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [Uploading an image to OCI](./user-guide/uploading-to-oci.md)
   - [Uploading container images](./user-guide/uploading-to-registry.md)
   - [OpenSCAP image remediation](./user-guide/oscap-remediation.md)
+  - [Repository customizations](./user-guide/repository-customizations.md)
 - [Blueprint reference](./blueprint-reference/blueprint-reference.md)
 - [Image Builder service architecture](./image-builder-service/architecture.md)
   - [Backend](./image-builder-service/image-builder-crc.md)

--- a/osbuild-composer/src/blueprint-reference/blueprint-reference.md
+++ b/osbuild-composer/src/blueprint-reference/blueprint-reference.md
@@ -295,6 +295,48 @@ data = "Hello world!"
 
 Note that the `data` property can be specified in any of the ways supported by TOML. Some of them require escaping certain characters and others don't. Please refer to the [TOML specification](https://toml.io/en/v1.0.0#string) for more details.
 
+## Custom Repositories
+
+Third-party repositories are supported by the blueprint customizations. A repository can be defined and enabled in the blueprints which will then be saved to the `/etc/yum.repos.d` directory in an image.
+An optional `filename` argument can be set, otherwise the repository will be saved using the the repository ID, i.e. `/etc/yum.repos.d/<repo-id>.repo`. 
+
+Please note custom repositories **cannot be used at build time to install third-party packages**. These customizations are used to save and enable third-party repositories on the image. For more information, or if you 
+wish to install a package from a third-party repository, please continue reading [here](../user-guide/repository-customizations.md).
+
+The following example can be used to create a third-party repository:
+
+```toml
+[[customizations.repositories]]
+id = "example"
+name="Example repo"
+baseurls=[ "https://example.com/yum/download" ]
+gpgcheck=true
+gpgkeys = [ "https://example.com/public-key.asc" ]
+enabled=true
+```
+
+Since no filename is specified, the repo will be saved to `/etc/yum.repos.d/example.repo`.
+
+The blueprint accepts the following options:
+
+- `id` (required)
+- `name`
+- `filename`
+- `baseurls` (array)
+- `mirrorlist`
+- `metalink`
+- `gpgkeys` keys (array)
+- `gpgcheck`
+- `repo_gpgcheck`
+- `priority`
+- `ssl_verify`
+
+*Note: the `baseurls` and `gpgkeys` fields both accept arrays as input. One of `baseurls`, `metalink` & `mirrorlist` must be provided*
+
+#### Repository GPG Keys
+The blueprint accepts both inline GPG keys and GPG key urls. If an inline GPG key is provided it will be saved to the `/etc/pki/rpm-gpg` directory and will be referenced accordingly
+in the repository configuration. **GPG keys are not imported to the RPM database** and will only be imported when first installing a package from the third-party repository.
+
 ## Distribution selection with blueprints
 
 The blueprint now supports a new `distro` field that will be used to select the

--- a/osbuild-composer/src/user-guide/repository-customizations.md
+++ b/osbuild-composer/src/user-guide/repository-customizations.md
@@ -1,0 +1,29 @@
+# Third-party Repositories
+
+`osbuild-composer` supports adding packages from third-party repositories and saving the repository customizations
+to an image. This guide aims to clarify each usecase and how to configure `osbuild-composer` and
+the blueprints accordingly.
+
+Very importantly, `osbuild-composer` has two distinct definitions of third-party repositories. Firstly, **payload repositories** which can be used to install third-party packages at build time and,
+secondly, **custom repositories** which are used to persist the repository configurations to the image.
+
+This could lead to the following desired usecases:
+1. Install a third-party package
+2. Save the third-party repository configurations to the image
+3. Install a third-party package **and** save the configurations
+
+## 1. Install a third-party package
+To install a third-party package at build time, it is necessary to enable the required third-party repository as a payload repository. This will not save any of the repository configurations
+to the image and will not make the repositories available to users on the system after the image has been built. For further information on how to install and configure `osbuild-composer`
+to use custom repositories for installing third-party packages, continue reading [here](./managing-repositories.md).
+
+
+## 2. Save repository configurations
+In the second scenario, to make third-party repository configurations persistent and make the repositories available to users on the system, one would use the blueprint `custom repository`
+configurations to enable this. The repository will be configured and saved to `/etc/yum.repos.d` as a `.repo` file. GPG keys are not imported at build time, but are imported when first 
+installing a third-party package from the desired repository. You can find the blueprint reference for custom repositories [here](../blueprint-reference/blueprint-reference.md).
+
+## 3. Install a third-party package and save configurations
+In this case it is necessary to use a combination of payload repositories and custom repositories in order to achieve the desired outcome. This will ensure that the package is installed during 
+build time and the repository configuration is saved to disk for future use. If the user only needs the package or the configuration file, they can use the appropriate repository type to achieve
+their goal.


### PR DESCRIPTION
Add a brief explaination on the differences between payload repositories and custom repository configurations that get saved to the `/etc/yum.repos.d` directory of a built image.

Add the blueprint-reference for the blueprint repository customizations.