### PR TITLE
service: Add open source notice

### DIFF
--- a/osbuild-composer/src/image-builder-service/architecture.md
+++ b/osbuild-composer/src/image-builder-service/architecture.md
@@ -1,5 +1,7 @@
 ## Service architecture
 
+This service is open source, so all of its code is inspectable and can be contributed to.
+
 {{#include architecture.svg}}
 
 > Click each component in this diagram to get to the **hash** of the source code **currently running in production**.


### PR DESCRIPTION
Add a sentence that echoes what users coming from our open source service badge (see screenshot below) read. In the future, the open source services logo will also go next to this sentence or in the section.

![image](https://github.com/osbuild/guides/assets/261436/231d8865-65b3-4a5b-b068-fdbe9de9e36d)
