### PR TITLE
Add redirects for some pages

### DIFF
--- a/src/blueprint-reference/blueprint-reference.html
+++ b/src/blueprint-reference/blueprint-reference.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html</title>
+<meta http-equiv="refresh" content="0; URL=https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html">
+<link rel="canonical" href="https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html">
+

--- a/src/user-guide/building-ostree-images.html
+++ b/src/user-guide/building-ostree-images.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html</title>
+<meta http-equiv="refresh" content="0; URL=https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html">
+<link rel="canonical" href="https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html">
+

--- a/src/user-guide/managing-repositories.html
+++ b/src/user-guide/managing-repositories.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://www.osbuild.org/guides/image-builder-on-premises/managing-repositories.html</title>
+<meta http-equiv="refresh" content="0; URL=https://www.osbuild.org/guides/image-builder-on-premises/managing-repositories.html">
+<link rel="canonical" href="https://www.osbuild.org/guides/image-builder-on-premises/managing-repositories.html">
+

--- a/src/user-guide/uploading-to-cloud.html
+++ b/src/user-guide/uploading-to-cloud.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://www.osbuild.org/guides/image-builder-on-premises/uploading-to-cloud.html</title>
+<meta http-equiv="refresh" content="0; URL=https://www.osbuild.org/guides/image-builder-on-premises/uploading-to-cloud.html">
+<link rel="canonical" href="https://www.osbuild.org/guides/image-builder-on-premises/uploading-to-cloud.html">
+


### PR DESCRIPTION
These pages are referred to by the man pages of composer-cli, so we should redirect to their new location. This mechanism can also be used in the future to add redirects to other pages that have moved.

See also https://github.com/osbuild/weldr-client/pull/114