### PR TITLE
Fix: Update broken link

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -24,7 +24,7 @@ Image Builder can also be deployed and self-hosted. In its most basic setup, it 
 
 All of our code is open source and [on GitHub](https://github.com/osbuild).
 
-Our [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html) is a great starting point to learn about our workflow, code style and more!
+Our [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) is a great starting point to learn about our workflow, code style and more!
 
 ### How to reach out to us
 


### PR DESCRIPTION
When user was navigating to developers guide using link on the main documentation page result was 404 error.
This PR fixes the link to point main index page of developer guide instead.