### PR TITLE
blueprint: add FDO section

### DIFF
--- a/src/image-builder-on-premises/blueprint-reference.md
+++ b/src/image-builder-on-premises/blueprint-reference.md
@@ -160,6 +160,7 @@ In the customizations we determine what goes into the image that's not in the de
   - [Files](#files)
 - [Installation device](#installation-device)
 - [Ignition](#ignition)
+- [FDO](#fdo)
 - [Repositories](#repositories)
 - [Filesystems](#filesystems)
 - [OpenSCAP](#openscap)
@@ -429,6 +430,7 @@ the destination device for the installation.
 [customizations]
 installation_device = "/dev/sda"
 ```
+
 ### Ignition
 
 The `customizations.ignition` section allows users to provide [Ignition](https://coreos.github.io/ignition/) configuration files to be used in `edge-raw-image` and `edge-simplified-installer` images. Check the RHEL for Edge (`r4e`) [butane](https://coreos.github.io/butane/specs/) specification for a description of the supported configuration options.
@@ -452,6 +454,23 @@ url = "http://some-server/configuration.ig"
 ```
 
 Add a URL pointing to the Ignition configuration that will be fetched during the first boot in the `url` field. Available for both `edge-simplified-installer` and `edge-raw-image`.
+
+### FDO
+
+The `customizations.fdo` section allows users to configure [FIDO Device Onboard (FDO)](https://github.com/fdo-rs/fido-device-onboard-rs) device initialization parameters. It is only available with the `edge-simplified-installer` or `iot-simplified-installer` image types.
+
+The `manufacturing_server_url` is a required field.
+
+The user must choose one of the device initalization methods providing `diun_pub_key_insecure`, `diun_pub_key_hash` or `diun_pub_key_root_certs`.
+
+The user may provide an IFACE name at `di_mfg_string_type_mac_iface`.
+
+```toml
+[customizations.fdo]
+manufacturing_server_url = "http://192.168.122.199:8080"
+diun_pub_key_insecure = "true"
+di_mfg_string_type_mac_iface = "enp2s0"
+```
 
 ### Repositories
 


### PR DESCRIPTION
Adds the FDO section to on-prem, explains the different customization options.